### PR TITLE
-- runtime/app.d

### DIFF
--- a/source/dpp/runtime/app.d
+++ b/source/dpp/runtime/app.d
@@ -246,8 +246,10 @@ string preamble() @safe pure {
         import core.stdc.config;
         import core.stdc.stdarg: va_list;
         static import core.simd;
-        static import std.conv;
 
+        template __from(string moduleName) {
+            mixin("import from = " ~ moduleName ~ ";");
+        }
         struct DppOffsetSize{ long offset; long size; }
         struct Int128 { long lower; long upper; }
         struct UInt128 { ulong lower; ulong upper; }

--- a/source/dpp/runtime/context.d
+++ b/source/dpp/runtime/context.d
@@ -327,7 +327,7 @@ struct Context {
 
         // parens and a type inside, where "a type" is any we know about
         const regexStr = `\(( *?(?:` ~ typeSelectionStr ~ `) *?)\)`;
-
+    
         return regex(regexStr);
     }
 

--- a/source/dpp/translation/macro_.d
+++ b/source/dpp/translation/macro_.d
@@ -131,5 +131,5 @@ private string fixOctal(in string str) @safe pure {
     if(!isOctal) return str;
 
     const firstNonZero = stripped.countUntil!(a => a != '0');
-    return ` std.conv.octal!` ~ stripped[firstNonZero .. $];
+    return ` __from!"std.conv.octal".` ~ stripped[firstNonZero .. $];
 }

--- a/source/dpp/translation/namespace.d
+++ b/source/dpp/translation/namespace.d
@@ -34,7 +34,7 @@ string[] translateNamespace(in from!"clang".Cursor cursor,
 
     string[] bodyLines;
 
-    lines ~= [
+    auto preludeLines = [
             `extern(C++, ` ~ cursor.spelling ~ `)`,
             `{`,
     ];


### PR DESCRIPTION
    not going to go well to static import std.conv, so I replaced it by from!"std.conv"

+++ b/source/dpp/translation/aggregate.d
    added isScopedEnum to detect class enums - needs cleaning up from C example
    these are skipped for C style declarations

+++ b/source/dpp/translation/macro_.d
    if it is octal:
+    return ` __from!"std.conv.octal".` ~ stripped[firstNonZero .. $];